### PR TITLE
Changed failmessage when entering unkown command

### DIFF
--- a/remote-processor/RemoteCommandHandlerTemplate.h
+++ b/remote-processor/RemoteCommandHandlerTemplate.h
@@ -164,7 +164,7 @@ private:
         if (!pRemoteCommandParserItem) {
 
             // Not found
-            strResult = "Command not found!";
+            strResult = "Command not found!\nUse \"help\" to show available commands";
 
             return false;
         }


### PR DESCRIPTION
New users should be aware of the existence
of the "help" command when they try the
pfw for their first time
