### PR TITLE
Added cmake rules for installing tools in bin dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,5 @@ add_subdirectory(remote-processor)
 
 add_subdirectory(remote-process)
 add_subdirectory(test/test-platform)
+
+add_subdirectory(tools/xmlGenerator)

--- a/tools/xmlGenerator/CMakeLists.txt
+++ b/tools/xmlGenerator/CMakeLists.txt
@@ -1,0 +1,9 @@
+install(PROGRAMS
+    domainGenerator.sh
+    hostConfig.py
+    hostDomainGenerator.sh
+    lightRoutingUpdate.sh
+    PFWScriptGenerator.py
+    portAllocator.py
+    updateRoutageDomains.sh
+    DESTINATION bin)


### PR DESCRIPTION
When performing the tutorials, I wanted to use the
tools/xmlGenerator/hostDomainGenerator.sh script.

In order to do that, i had to copy manually my scripts files
to the pfwInstalledDir/bin directory.
This patchs completes the install target by copying the needed files
