### PR TITLE
Fixed infinite loop plugin loading

### DIFF
--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -237,11 +237,12 @@ bool CSystemClass::loadPlugins(list<string>& lstrPluginFiles, list<string>& lstr
         // Load symbol from library
         GetSubsystemBuilder pfnGetSubsystemBuilder = (GetSubsystemBuilder)dlsym(lib_handle, strPluginSymbol.c_str());
 
-        if (!pfnGetSubsystemBuilder) {
+        if (pfnGetSubsystemBuilder == NULL) {
 
             lstrError.push_back("Subsystem plugin " + strPluginFileName +
                                 " does not contain " + strPluginSymbol + " symbol.");
-
+            // Next plugin
+            ++it;
             continue;
         }
 


### PR DESCRIPTION
When having unresolved symbols in a plugin (for eg the getTYPESubsystemBuilder
function has a typo) the parameter framework loops infinitely
on the finding of that symbol.

This patchs fixs the issue by loading the next plugin instead of trying
infinitely to load the same plugin
