### PR TITLE
Allow the plugin libraries to have empty path for location

### DIFF
--- a/parameter/SystemClass.cpp
+++ b/parameter/SystemClass.cpp
@@ -134,8 +134,10 @@ bool CSystemClass::loadSubsystemsFromSharedLibraries(list<string>& lstrError,
         // Get Folder for current Plugin Location
         const CPluginLocation* pPluginLocation = static_cast<const CPluginLocation*>(pSubsystemPlugins->getChild(uiPluginLocation));
 
-        const string& strFolder = pPluginLocation->getFolder();
-
+        string strFolder(pPluginLocation->getFolder());
+        if (!strFolder.empty()) {
+            strFolder += "/";
+        }
         // Iterator on Plugin List:
         list<string>::const_iterator it;
 
@@ -144,7 +146,7 @@ bool CSystemClass::loadSubsystemsFromSharedLibraries(list<string>& lstrError,
         for (it = pluginList.begin(); it != pluginList.end(); ++it) {
 
             // Fill Plugin files list
-            lstrPluginFiles.push_back(strFolder + "/" + *it);
+            lstrPluginFiles.push_back(strFolder + *it);
         }
     }
 


### PR DESCRIPTION
When specifying a path for the plugin location folder, a slash used to be appended to the path.

According to dlopen manual:

```
If  filename  contains  a  slash ("/"), then it is interpreted as a (relative or absolute) pathname
```

So when we were specifying an empty location, we wanted to use the default location. Due to the slash appending, `dlopen()` was searching for plugin names in `/`, which obviously fails.
