### PR TITLE
Fix a use-after-free issue

### DIFF
--- a/parameter/BinaryStream.cpp
+++ b/parameter/BinaryStream.cpp
@@ -46,12 +46,12 @@ CBinaryStream::CBinaryStream(const string& strFileName, bool bOut, uint32_t uiDa
 
 CBinaryStream::~CBinaryStream()
 {
-    delete [] _puiData;
-
     if (_bOpen) {
 
         close();
     }
+
+    delete [] _puiData;
 }
 
 bool CBinaryStream::open(string& strError)


### PR DESCRIPTION
In CBinaryStream, a member gets used after it has been destroyed. This was
caught by a static code analyser.
