### PR TITLE
hostDomainGenerator: Fix the stripping of the temporary directory name

### DIFF
--- a/tools/xmlGenerator/hostDomainGenerator.sh
+++ b/tools/xmlGenerator/hostDomainGenerator.sh
@@ -313,5 +313,5 @@ m4 "$@" |
 $PFWSendCommand getDomainsWithSettingsXML |
     # Delete trailing carriage return and format absolute paths
     sed -r -e 's/\r$//' \
-           -e 's/(xsi:noNamespaceSchemaLocation=")[^"]*tmp/\1/' >&4
+           -e 's@(xsi:noNamespaceSchemaLocation=")'"$tmpDir"'/?@\1@' >&4
 


### PR DESCRIPTION
We didn't properly remove the name of the temporary directory in the generated
files which caused two generation from identical sources result in different
generated files.

We know the full name of the temporary directory so we can simply completly
remove it from the generated file.

Issue: GMINL-1953
Change-Id: I1f360cea249328d30318a24643b524c87424475e
Signed-off-by: David Wagner david.wagner@intel.com
We know the full name of the temporary directory so we can simply completly
remove it from the generated file.

Issue: GMINL-1953
Change-Id: I1f360cea249328d30318a24643b524c87424475e
Signed-off-by: David Wagner david.wagner@intel.com
