### PR TITLE
Remove flood debug trace on xml generation error

### DIFF
--- a/tools/xmlGenerator/hostDomainGenerator.sh
+++ b/tools/xmlGenerator/hostDomainGenerator.sh
@@ -99,15 +99,6 @@ clean_up () {
     status=$?
     set +e # An error should not abort clean up
 
-    ( if test $status -ne 0
-    then
-        echo "$0 is exiting on error, printing debug information."
-        echo "Test platform port: $TPSocket"
-        echo "PFW port: $PFWSocket"
-        netstat --program --all --numeric --extend --tcp
-        ps -ejHlf
-    fi ) >&5
-
     # Exit the test-platform only if it was created by this process
     if $TPCreated
     then


### PR DESCRIPTION
The patch 0b3ff88 "Add log in case of failure" added system process and network log on failure.
It was planed to be used to debug a tricky socket error bug.
The bug was since fixed and the traces now only flood build log, making xml generation error root cause spotting a lot harder.

Remove extra debug message (netstat and ps invocation) on error.
