### PR TITLE
Clarify the "Non accessible element" error

### DIFF
--- a/parameter/ConfigurableElement.cpp
+++ b/parameter/ConfigurableElement.cpp
@@ -139,7 +139,7 @@ bool CConfigurableElement::accessValue(CPathNavigator& pathNavigator, std::strin
 
     if (!pStrChildName) {
 
-        parameterAccessContext.setError("Non accessible element");
+        parameterAccessContext.setError((bSet ? "Can't set " : "Can't get ") + pathNavigator.getCurrentPath() + " because it is not a parameter");
 
         return false;
     }


### PR DESCRIPTION
This error happens, among others, when trying to set an element as if it was a
parameter. The error message was not very helpful.
